### PR TITLE
feat: implement asynchronous update check scheduling

### DIFF
--- a/lua/nvim_updater/init.lua
+++ b/lua/nvim_updater/init.lua
@@ -571,12 +571,14 @@ function P.setup(user_config)
 	-- Setup Neovim user commands
 	P.setup_usercmds()
 
-	-- Check for updates
+	-- Schedule async update check
 	if P.default_config.check_for_updates then
-		utils.get_commit_count()
-		if P.default_config.update_interval > 0 then
-			utils.update_timer(P.default_config.update_interval)
-		end
+		vim.defer_fn(function()
+			utils.get_commit_count()
+			if P.default_config.update_interval > 0 then
+				utils.update_timer(P.default_config.update_interval)
+			end
+		end, 50)
 	end
 end
 


### PR DESCRIPTION
### Significantly decreases initial plugin startup time!

By deferring the update check, lazy.nvim and the like will no longer wait for the update-check function to complete before registering as "started"

Startup times should now be noticeably faster with the update check enabled!