### PR TITLE
👽 Compat(termopen): update deprecated api call for termopen

### DIFF
--- a/lua/nvim_updater/utils.lua
+++ b/lua/nvim_updater/utils.lua
@@ -293,7 +293,8 @@ function U.open_floating_terminal(command_or_opts, filetype, ispreupdate, autocl
 	end
 
 	-- Run the terminal command
-	vim.fn.termopen(command, {
+	vim.fn.jobstart(command, {
+		term = true, -- Use terminal mode
 		on_stdout = function(_, data)
 			if data then
 				for _, line in ipairs(data) do


### PR DESCRIPTION
Use the recommended vim.fn.jobstart over deprecated vim.fn.termopen

Please let me know if this causes any issues with older nvim versions. In my testing it seems to work well but I can implement a version check if needed for compatibility on older installs.